### PR TITLE
feat: add compact input size

### DIFF
--- a/src/components/CTA.tsx
+++ b/src/components/CTA.tsx
@@ -44,15 +44,15 @@ export function CTA() {
               
               <div className="space-y-6">
                 <div className="space-y-4">
-                  <Input 
-                    type="email" 
+                  <Input
+                    type="email"
                     placeholder="Ihre E-Mail-Adresse"
-                    className="text-lg py-6 border-2"
+                    size="sm"
                   />
-                  <Input 
-                    type="text" 
+                  <Input
+                    type="text"
                     placeholder="Firmenname"
-                    className="text-lg py-6 border-2"
+                    size="sm"
                   />
                 </div>
                 

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,16 +1,33 @@
 import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
 
-const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-  ({ className, type, ...props }, ref) => {
+const inputVariants = cva(
+  "flex w-full rounded-md border border-input bg-background px-3 ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+  {
+    variants: {
+      size: {
+        default: "h-10 py-2 text-base md:text-sm",
+        sm: "h-8 py-1 text-sm",
+      },
+    },
+    defaultVariants: {
+      size: "default",
+    },
+  }
+)
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement>,
+    VariantProps<typeof inputVariants> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, size, ...props }, ref) => {
     return (
       <input
         type={type}
-        className={cn(
-          "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-          className
-        )}
+        className={cn(inputVariants({ size, className }))}
         ref={ref}
         {...props}
       />

--- a/src/pages/Support.tsx
+++ b/src/pages/Support.tsx
@@ -158,6 +158,7 @@ const Support = () => {
                         value={formData.firstName}
                         onChange={(e) => setFormData({ ...formData, firstName: e.target.value })}
                         placeholder="Ihr Vorname"
+                        size="sm"
                       />
                     </div>
                     <div className="space-y-2">
@@ -168,10 +169,11 @@ const Support = () => {
                         value={formData.lastName}
                         onChange={(e) => setFormData({ ...formData, lastName: e.target.value })}
                         placeholder="Ihr Nachname"
+                        size="sm"
                       />
                     </div>
                   </div>
-                  
+
                   <div className="space-y-2">
                     <Label htmlFor="email">E-Mail *</Label>
                     <Input
@@ -181,9 +183,10 @@ const Support = () => {
                       value={formData.email}
                       onChange={(e) => setFormData({ ...formData, email: e.target.value })}
                       placeholder="ihre.email@beispiel.com"
+                      size="sm"
                     />
                   </div>
-                  
+
                   <div className="space-y-2">
                     <Label htmlFor="company">Unternehmen</Label>
                     <Input
@@ -191,6 +194,7 @@ const Support = () => {
                       value={formData.company}
                       onChange={(e) => setFormData({ ...formData, company: e.target.value })}
                       placeholder="Ihr Unternehmen (optional)"
+                      size="sm"
                     />
                   </div>
                   
@@ -222,6 +226,7 @@ const Support = () => {
                       value={formData.subject}
                       onChange={(e) => setFormData({ ...formData, subject: e.target.value })}
                       placeholder="Kurze Beschreibung Ihres Anliegens"
+                      size="sm"
                     />
                   </div>
                   


### PR DESCRIPTION
## Summary
- add `sm` size variant for Input component
- use compact inputs in CTA and Support forms

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type in textarea.tsx; @typescript-eslint/no-require-imports in tailwind.config.ts)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af4eb9aa6c83289d116811066074e3